### PR TITLE
Updated the platform history page

### DIFF
--- a/history/index.html
+++ b/history/index.html
@@ -361,7 +361,7 @@ Web Forms 2.0
 <li><code>createTBody()</code> for the <code>table</code> element
 <li><code>showModalDialog()</code>
 <li><code>document.domain</code>
-<li><code>&lt;source pixelratio></code>
+<li><code>&lt;source pixelratio> (later dropped)</code>
 <li><code>bufferedBytes</code>, <code>totalBytes</code> and <code>bufferingThrottled</code> IDL attributes for the <code>video</code> element (later dropped)
 </ul>
 
@@ -428,7 +428,7 @@ Web Forms 2.0
 <li><code>&lt;audio loop></code> and <code>&lt;video loop></code>
 <li><code>canPlayType()</code> on <code>audio</code> and <code>video</code> elements
 <li><code>location.resolveURL()</code> on <code>location</code> (later dropped, later replaced by <code>URL()</code> constructor)
-<li><code>unload</code> on <code>beforeunload</code> events
+<li><code>unload</code> and <code>beforeunload</code> events
 </ul>
 
 <dt>2009-02 through 2009-04</dt>
@@ -515,7 +515,7 @@ Web Forms 2.0
 <dd>
 <ul>
 <li><code>toBlob()</code> method on <code>canvas</code> element
-<li><code>selectDirection</code> IDL attribute on <code>input</code> and <code>textarea</code> elements
+<li><code>selectionDirection</code> IDL attribute on <code>input</code> and <code>textarea</code> elements
 <li><code>MediaController</code> API and the <code>mediagroup</code> attribute
 </ul>
 


### PR DESCRIPTION
- Fixed a typo (it was "on" instead of "and").
- Fixed an IDL property name (it was "selectDirection" instead of "selectionDirection").
- Clarified that <source pixelratio> was later dropped.
