### PR TITLE
remove asterisks on `.XXX`

### DIFF
--- a/style/specification
+++ b/style/specification
@@ -142,7 +142,6 @@ span.note { padding: 0 2em; }
 .note p:last-child, .warning p:last-child { margin-bottom: 0; }
 .warning:before { font-style: normal; }
 
-.XXX:before, .XXX:after { content: " ** "; position: absolute; left: 0; width: 8em; text-align: right; }
 p.note:before { content: 'Note: '; }
 p.warning:before { content: '\26A0 Warning! '; }
 


### PR DESCRIPTION
I'm not sure what's the expected style, but I changed the `**` to be consistent in both Chrome and Firefox.

Tested against https://fullscreen.spec.whatwg.org/.
# Chrome
# Before                              After

<a href="https://cloud.githubusercontent.com/assets/203725/5095271/3f774316-6f1d-11e4-8ed6-aa5d3d637e4c.png"><img src="https://cloud.githubusercontent.com/assets/203725/5095271/3f774316-6f1d-11e4-8ed6-aa5d3d637e4c.png" width="48%"></a>    <a href="https://cloud.githubusercontent.com/assets/203725/5095270/3f580726-6f1d-11e4-80cf-84937b9163f2.png"><img src="https://cloud.githubusercontent.com/assets/203725/5095270/3f580726-6f1d-11e4-80cf-84937b9163f2.png" width="48%"></a>
# Firefox
# Before                              After

<a href="https://cloud.githubusercontent.com/assets/203725/5095272/3f7ac52c-6f1d-11e4-942b-ba7fb05f8063.png"><img src="https://cloud.githubusercontent.com/assets/203725/5095272/3f7ac52c-6f1d-11e4-942b-ba7fb05f8063.png" width="48%"></a>    <a href="https://cloud.githubusercontent.com/assets/203725/5095273/3f7e2da2-6f1d-11e4-8784-dcb93db7a693.png"><img src="https://cloud.githubusercontent.com/assets/203725/5095273/3f7e2da2-6f1d-11e4-8784-dcb93db7a693.png" width="48%"></a>
