### PR TITLE
Update HTML5Please status of classList

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
   <a class=mdn href="https://developer.mozilla.org/en/DOM/element.classList">ⓜ</a>
   <a class=mdn href="https://developer.mozilla.org/en/DOM/DOMTokenList">ⓜ</a>
   <a class=tests href="http://w3c-test.org/html/tests/submission/Opera/classList/">ⓣ</a>
-  <a class=pleaseCaution href="http://html5please.com/#classList">❢</a>
+  <a class=pleaseUse href="http://html5please.com/#classList">⚑</a>
   <dd><a href="https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes">dataset (data-* attributes)</a>
   <a class=caniuse href="http://caniuse.com/#search=dataset">ⓤ</a>
   <a class=tests href="http://w3c-test.org/html/tests/submission/Apple/dataset/">ⓣ</a>


### PR DESCRIPTION
H5P lists classList as "use with polyfill", not "use with caution". If this page looks to draw a distinction between "use with polyfill" and "use", it needs to similarly distinguish it from "use with caution".