### PR TITLE
Prevent ⓣests from getting an extra ⓦ icon

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ a[href*=whatwg]:not([href*=github]):before {
   padding-right: 4px;
 }
 a[href*=dev\.w3\.org]:before,
-a[href*=www\.w3\.org]:before,
+a[href*=www\.w3\.org]:not(.tests):before,
 a[href*=dvcs\.w3\.org]:before,
 a[href*=heycam\.github\.io]:before,
 a[href*=slightlyoff\.github\.io]:before,


### PR DESCRIPTION
Some of the tests suites are hosted on www.w3.org, so they were getting an extra ⓦ3C standard icon, which was confusing.
This change breaks IE8 compatibility (since IE8 doesn't support `:not()`), hence why I'm putting this out for review.
CC: @sideshowbarker 