### PR TITLE
Add Link to Text Fragment

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,6 +402,9 @@
   <a class=tests href="http://w3c-test.org/html/editing/editing-0/contenteditable/">ⓣ</a>
   <dd><a href="http://www.w3.org/TR/wai-aria/">ARIA</a>
   <a class=caniuse href="http://caniuse.com/#feat=wai-aria">ⓤ</a>
+  <dd><a href="https://wicg.github.io/scroll-to-text-fragment/">Text Fragments</a>
+  <a class=caniuse href="https://caniuse.com/url-scroll-to-text-fragment">ⓤ</a>
+  <a class=tests href="https://github.com/WICG/scroll-to-text-fragment">ⓣ</a>
 </dl>
 <dl>
   <dt>Performance optimization and analysis</dt>


### PR DESCRIPTION
**Text Fragments** adds support for specifying a text snippet in the URL fragment. When navigating to a URL with such a fragment, the user agent can quickly emphasise and/or bring it to the user’s attention. Please check the [spec](https://wicg.github.io/scroll-to-text-fragment/).